### PR TITLE
Define USE_SSL in horizon's local_settings.py if needed

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -138,7 +138,11 @@ DATABASES = {
 EODASHDB
 fi
 
-sed -i -e "s/^USE_SSL =.*/USE_SSL = True/" $DASHBOARD_LOCAL_SET
+if grep -q "^USE_SSL =" $DASHBOARD_LOCAL_SET; then
+  sed -i -e "s/^USE_SSL =.*/USE_SSL = True/" $DASHBOARD_LOCAL_SET
+else
+  echo "USE_SSL = True" >> $DASHBOARD_LOCAL_SET
+fi
 # Use 'secure' session and CSRF cookies (bnc#753582):
 cat >> $DASHBOARD_LOCAL_SET <<EOSEC
 # Use 'secure' cookies when we use SSL, see https://docs.djangoproject.com/en/1.4/topics/security/:


### PR DESCRIPTION
grep for USE_SSL before sed'ing, and just append "USE_SSL = True" if
there's nothing to sed.

Fix a crash when running syncdb for horizon.
