### PR TITLE
FIx quantum client invocation on SLES11 and separate DNSMASQ driver for SLES11

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -121,6 +121,13 @@ function update_iproute2_on_opensuse_12_3 () {
      fi
 }
 
+function dhcp_agent_platform_specific () {
+     grep -q 'SUSE Linux Enterprise Server 11' /etc/SuSE-release
+     if [[ $? -eq 0 ]] ; then
+          openstack-config  --set /etc/quantum/dhcp_agent.ini DEFAULT dhcp_driver quantum.agent.linux.dhcp.DnsmasqSles
+     fi
+}
+
 
 
 update_iproute2_on_opensuse_12_3
@@ -418,6 +425,8 @@ openstack-config  --set /etc/quantum/plugins/linuxbridge/linuxbridge_conf.ini VL
 openstack-config  --set /etc/quantum/l3_agent.ini DEFAULT external_network_bridge ""
 ### turnof namespace to allow connecting to VMs from demo admin node (simple setup for demo purposes only)
 openstack-config  --set /etc/quantum/dhcp_agent.ini DEFAULT use_namespaces False
+### dhcp_agent platform specific settings
+dhcp_agent_platform_specific
 ### start quantum api
 start_and_enable_service rabbitmq-server
 start_and_enable_service openstack-quantum


### PR DESCRIPTION
On SLES11 -c as a parameter to quantum client is not working replace it with -F.

On SLES11 dedicated dnsmasq driver is required as dnsmasq version present there doesn't support tag feature.
