### PR TITLE
Enable use_namespaces consistently for dhcp and l3 agents

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -440,10 +440,11 @@ fi
 crudini --set /etc/neutron/neutron.conf database connection $DB://neutron:$mpw@$IP/neutron
 
 crudini --set /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini linux_bridge physical_interface_mappings root-bridge:vefq,physnet1:eth0
+crudini --set /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini securitygroup firewall_driver neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
 # crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types vlan
 crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vlan network_vlan_ranges root-bridge,physnet1
-crudini --set /etc/neutron/dhcp_agent.ini DEFAULT use_namespaces false
-#crudini --set /etc/neutron/dhcp_agent.ini DEFAULT use_namespaces true
+crudini --set /etc/neutron/dhcp_agent.ini DEFAULT use_namespaces true
+crudini --set /etc/neutron/l3_agent.ini DEFAULT use_namespaces true
 crudini --set /etc/neutron/neutron.conf DEFAULT allow_overlapping_ips true
 crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secret $metadata_secret
 


### PR DESCRIPTION
Also add a firewall_driver setting to the linuxbridge agent's config to unbreak
floating IPs.
