### PR TITLE
Corrected linuxbridge config file location

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -315,9 +315,9 @@ crudini --set $c DEFAULT nova_admin_tenant_id $SERVICE_TENANT_ID
 crudini --set $c DEFAULT nova_admin_auth_url $KEYSTONE_PUBLIC_ENDPOINT
 
 
-crudini --set /etc/neutron/plugins/ml2/linuxbridge_agent.ini linux_bridge physical_interface_mappings physnet1:$TENANT_ETH
-crudini --set /etc/neutron/plugins/ml2/linuxbridge_agent.ini securitygroup firewall_driver neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
-crudini --set /etc/neutron/plugins/ml2/linuxbridge_agent.ini vxlan enable_vxlan False
+crudini --set /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini linux_bridge physical_interface_mappings physnet1:$TENANT_ETH
+crudini --set /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini securitygroup firewall_driver neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+crudini --set /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini vxlan enable_vxlan False
 crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 tenant_network_types vlan
 crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2 type_drivers local,flat,vlan
 crudini --set /etc/neutron/plugins/ml2/ml2_conf.ini ml2_type_vlan network_vlan_ranges physnet1:$TENANT_VLAN_RANGE


### PR DESCRIPTION
For me there was no /etc/neutron/plugins/ml2/linuxbridge_agent.ini but only a /etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini on SLE12 with OBS Kilo that contained the settings that were trying to be set.