### PR TITLE
Enable Nova API V3 (and V2.1)

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -225,6 +225,7 @@ crudini --set /etc/nova/nova.conf DEFAULT osapi_compute_workers "1"
 crudini --set /etc/nova/nova.conf DEFAULT ec2_workers "1"
 crudini --set /etc/nova/nova.conf DEFAULT metadata_workers "1"
 crudini --set /etc/nova/nova.conf conductor workers "1"
+crudini --set /etc/nova/nova.conf osapi_v3 enabled "true"
 
 metadata_secret=$(echo $ADMIN_PASSWORD | md5sum | cut -d" " -f1)
 crudini --set /etc/nova/nova.conf neutron service_metadata_proxy True


### PR DESCRIPTION
Nova API v2.1 is needed but is only enabled if also v3 is enabled.

This fixes:

$ nova --os-tenant-name admin secgroup-add-rule default icmp -1 -1 0.0.0.0/0
ERROR (ClientException): The server has either erred or is incapable of performing the requested operation

nova-api.log has:

TRACE nova.api.openstack AttributeError: 'APIRouterV21' object has no attribute '_router'