### PR TITLE
Enables deactivate image test

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -618,4 +618,5 @@ if [ "x$with_tempest" = "xyes" -a -e /etc/tempest/tempest.conf ]; then
     crudini --set /etc/tempest/tempest.conf stress max_instances 1
     crudini --set /etc/tempest/tempest.conf service_available horizon $with_horizon
     crudini --set /etc/tempest/tempest.conf volume-feature-enabled backup false
+    crudini --set /etc/tempest/tempest.conf image-feature-enabled deactivate_image true
 fi


### PR DESCRIPTION
We have backported the deactivate image feature to Cloud 5
and also added tempest tests for the same, and this patch
enables to test the feature in tempest config.
https://review.openstack.org/#/c/132717/
https://review.openstack.org/#/c/183700/