### PR TITLE
Fixes for manila

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -509,13 +509,14 @@ crudini --set $c DEFAULT nova_admin_auth_url $KEYSTONE_PUBLIC_ENDPOINT
 
 crudini --set $c DEFAULT neutron_admin_username neutron
 crudini --set $c DEFAULT neutron_admin_password $ADMIN_PASSWORD
-crudini --set $c DEFAULT neutron_admin_project_name $SERVICE_TENANT_ID
+crudini --set $c DEFAULT neutron_admin_project_name "service"
 crudini --set $c DEFAULT neutron_admin_auth_url $KEYSTONE_PUBLIC_ENDPOINT
 
 crudini --set $c DEFAULT cinder_admin_username cinder
 crudini --set $c DEFAULT cinder_admin_password $ADMIN_PASSWORD
-crudini --set $c DEFAULT cinder_admin_tenant_name $SERVICE_TENANT_ID
+crudini --set $c DEFAULT cinder_admin_tenant_name "service"
 crudini --set $c DEFAULT cinder_admin_auth_url $KEYSTONE_PUBLIC_ENDPOINT
+crudini --set $c DEFAULT share_volume_fstype ext3
 
 # create and enable a manila backend
 crudini --set $c DEFAULT enabled_share_backends backend-0
@@ -525,6 +526,7 @@ crudini --set $c backend-0 service_image_name manila-service-image
 crudini --set $c backend-0 driver_handles_share_servers true
 crudini --set $c backend-0 service_instance_user root
 crudini --set $c backend-0 service_instance_password ""
+crudini --set $c backend-0 interface_driver manila.network.linux.interface.BridgeInterfaceDriver
 
 nova flavor-create manila-service-image-flavor 100 256 0 1
 


### PR DESCRIPTION
- use share_volume_fstype ext3. Useful if you use a SLE11SP3 based
  service image
- set correct interface driver. we use linuxbridge for quickstart
- set correct service project name for cinder and neutron. The name
  is needed, not the id