### PR TITLE
Install manila tempest tests

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -25,7 +25,7 @@ fi
 if [ "x$with_tempest" = "xyes" ]; then
     install_packages openstack-nova-objectstore openstack-neutron-lbaas-agent \
         openstack-neutron-vpn-agent openstack-neutron-fwaas \
-        openstack-tempest-test
+        openstack-tempest-test openstack-manila-test
 fi
 
 # TODO: remove when manila packages are part of patterns!


### PR DESCRIPTION
Manila uses the new tempest plugin interface to add tempest tests.
So when running "testr list-tests" or "testr run", the tests need
to be installed.
This fixes:

ImportError: No module named manila_tempest_tests.plugin