### PR TITLE
restart wickedd before ifup

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -396,6 +396,7 @@ ext_bridge_cidr=`get_ext_bridge_cidr`
 
 if [ x$FLOATING_VLAN = x ]; then
     setup_ext_bridge_on_boot $ext_bridge_name $ext_bridge_ip $ext_bridge_cidr
+    systemctl restart wickedd
     ifup $ext_bridge_name
 fi
 #-----------------------------------------


### PR DESCRIPTION
otherwise it would fail in ifup on SP1 and Leap 42.1
with "brq... device-unconfigured"