### PR TITLE
Removed barbican-api-paste.ini handling.

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -239,14 +239,6 @@ fi
 if [ "x$with_barbican" = "xyes" ]; then
     setup_keystone_authtoken /etc/barbican/barbican.conf barbican
     crudini --set /etc/barbican/barbican.conf keystone_authtoken auth_version 'v3.0'
-    # FIXME: take into account differences between Mitaka and Master. We will
-    #        no longer need any of these once Barbican upstream defaults to
-    #        using Keystone authentication.
-    if grep filter:keystone_authtoken /etc/barbican/barbican-api-paste.ini; then
-      crudini --set /etc/barbican/barbican-api-paste.ini 'pipeline:barbican_api' 'pipeline' 'cors keystone_authtoken context apiapp'
-    else
-      crudini --set /etc/barbican/barbican-api-paste.ini 'pipeline:barbican_api' 'pipeline' 'cors authtoken context apiapp'
-    fi
 fi
 
 #-----------------------------------------


### PR DESCRIPTION
We no longer need this code since our packages ship a working `barbican-api-paste.ini` as of today.