### PR TITLE
[mitaka] Re-organize options for OpenStack Neutron Lbaas v2 service

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -377,6 +377,9 @@ crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secr
 
 if [ "x$with_tempest" = "xyes" ]; then
     crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins "neutron.services.loadbalancer.plugin.LoadBalancerPlugin, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, neutron.services.firewall.fwaas_plugin.FirewallPlugin"
+    # configure Neutron Lbaas v2 service
+    crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
+    crudini --set /etc/neutron/lbaas_agent.ini DEFAULT interface_driver neutron.agent.linux.interface.BridgeInterfaceDriver
 fi
 
 start_and_enable_service rabbitmq-server
@@ -387,7 +390,6 @@ if ! rabbitmqctl list_users|grep -q openstack; then
     rabbitmqctl set_permissions openstack ".*" ".*" ".*"
 fi
 
-
 # Start Keystone and Neutron
 for s in openstack-keystone \
     openstack-neutron openstack-neutron-linuxbridge-agent openstack-neutron-dhcp-agent \
@@ -397,8 +399,6 @@ do
 done
 
 if [ "x$with_tempest" = "xyes" ]; then
-    crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
-    crudini --set /etc/neutron/lbaas_agent.ini DEFAULT interface_driver neutron.agent.linux.interface.BridgeInterfaceDriver
     start_and_enable_service openstack-neutron-lbaasv2-agent
 fi
 


### PR DESCRIPTION
For OpenStack Mitaka option service_provider for Neutron Lbaas v2
service has to be configured, before openstack-neutron server will
be started.