### PR TITLE
Re-organize options for OpenStack Neutron Lbaas v2 service

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -442,6 +442,9 @@ crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secr
 
 if [ "x$with_tempest" = "xyes" ]; then
     crudini --set /etc/neutron/neutron.conf DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, neutron.services.firewall.fwaas_plugin.FirewallPlugin"
+    # configure Neutron Lbaas v2 service
+    crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
+    crudini --set /etc/neutron/lbaas_agent.ini DEFAULT interface_driver neutron.agent.linux.interface.BridgeInterfaceDriver
 fi
 
 start_and_enable_service rabbitmq-server
@@ -452,7 +455,6 @@ if ! rabbitmqctl list_users|grep -q openstack; then
     rabbitmqctl set_permissions openstack ".*" ".*" ".*"
 fi
 
-
 # Start Keystone and Neutron
 for s in openstack-keystone \
     openstack-neutron openstack-neutron-linuxbridge-agent openstack-neutron-dhcp-agent \
@@ -462,8 +464,6 @@ do
 done
 
 if [ "x$with_tempest" = "xyes" ]; then
-    crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
-    crudini --set /etc/neutron/lbaas_agent.ini DEFAULT interface_driver neutron.agent.linux.interface.BridgeInterfaceDriver
     start_and_enable_service openstack-neutron-lbaasv2-agent
 fi
 


### PR DESCRIPTION
For OpenStack Mitaka option service_provider for Neutron Lbaas v2
service has to be configured, before openstack-neutron server will
be started.

(cherry-picked from 53d9f8549d1dcf1ade1079ef56b1bc8086a6d324)

Conflicts:
	scripts/openstack-quickstart-demosetup