### PR TITLE
Start and enable virtlogd service on compute nodes

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -155,6 +155,7 @@ function setup_node_for_nova_compute() {
     fi
 
     start_and_enable_service libvirtd
+    start_and_enable_service virtlogd
 }
 
 function setup_nova_compute() {


### PR DESCRIPTION
This is needed since SLE12SP2 and fixes:

libvirtError: Failed to connect socket to '/var/run/libvirt/virtlogd-sock': \
              No such file or directory