### PR TITLE
Enable ml2_conf.ini for neutron-server

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -480,6 +480,10 @@ fi
 ## setup neutron configuration
 #-----------------------------------------
 
+# enable ml2 config in neutron-server
+mkdir -p /etc/neutron/neutron-server.conf.d/
+ln -s /etc/neutron/plugins/ml2/ml2_conf.ini /etc/neutron/neutron-server.conf.d/100-ml2_conf.ini.conf
+
 SERVICE_TENANT_ID=`get_service_tenant_id`
 c=/etc/neutron/neutron.conf
 crudini --set $c database connection $DB://neutron:$mpw@$IP/neutron


### PR DESCRIPTION
With the switch to systemd in the openstack-neutron packages,
there is no longer a default plugin activated.
So activate the previous default to get neutron-server working again.