### PR TITLE
Follow symlinks when changing files inplace with sed

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -356,9 +356,9 @@ if [ "x$with_gnocchi" = "xyes" ]; then
 fi
 
 for m in $service_list; do
-    sed -i -e 's/%SERVICE_TENANT_NAME%/service/' \
-           -e "s/%SERVICE_PASSWORD%/$ADMIN_PASSWORD/" \
-               /etc/$m/*.ini /etc/$m/$m*.conf
+    sed -i --follow-symlinks -e 's/%SERVICE_TENANT_NAME%/service/' \
+        -e "s/%SERVICE_PASSWORD%/$ADMIN_PASSWORD/" \
+        /etc/$m/*.ini /etc/$m/$m*.conf
 done
 
 


### PR DESCRIPTION
This is needed because neutron has now a symlink called
/etc/neutron/plugin.ini which points to the used core plugin.
When looping over the .ini files, the symlink should not be destroyed.