### PR TITLE
Use qemu instead of lxc as virt_type fallback

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -132,12 +132,14 @@ function setup_node_for_nova_compute() {
     crudini --set /etc/libvirt/libvirtd.conf "" auth_tcp '"none"'
     #crudini --set /etc/libvirt/libvirtd.conf "" listen_addr $MY_ADMINIP
 
-    grep -q -e vmx -e svm /proc/cpuinfo || MODE=lxc
+    grep -q -e vmx -e svm /proc/cpuinfo || MODE=qemu
     # use lxc or qemu, if kvm is unavailable
     if rpm -q openstack-nova-compute >/dev/null ; then
         if [ "$MODE" = lxc ] ; then
             crudini --set /etc/nova/nova.conf libvirt virt_type lxc
             install_packages lxc
+        elif [ "$MODE" = qemu ] ; then
+            crudini --set /etc/nova/nova.conf libvirt virt_type qemu
         else
             grep -qw vmx /proc/cpuinfo && {
                 modprobe kvm-intel

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -528,27 +528,38 @@ fi
 
 ### create subnets
 ## fixed
-neutron net-create fixed --tenant-id $SERVICE_TENANT_ID --shared --provider:network_type vlan \
-    --provider:segmentation_id $FIXED_VLAN  --provider:physical_network physnet1
-
-neutron subnet-create --name fixed --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4 fixed $testnet
-neutron router-create --tenant-id $SERVICE_TENANT_ID public
-neutron router-interface-add public fixed
-
-## floating/external
-if [ x$FLOATING_VLAN != x ]; then
-    neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type vlan \
-        --router:external --provider:segmentation_id $FLOATING_VLAN --provider:physical_network physnet1
-else
-    neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type local --router:external
+if ! neutron net-show fixed; then
+    neutron net-create fixed --tenant-id $SERVICE_TENANT_ID --shared --provider:network_type vlan \
+            --provider:segmentation_id $FIXED_VLAN  --provider:physical_network physnet1
 fi
 
-if [ x$FLOATING_VLAN != x ]; then
-    ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
-    neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID $floatingpool $floatinggateway ext $floatingnet
-else
-    ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
-    neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID ext $floatingnet
+if ! neutron subnet-show fixed; then
+    neutron subnet-create --name fixed --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4 fixed $testnet
+fi
+
+if ! neutron router-show public; then
+    neutron router-create --tenant-id $SERVICE_TENANT_ID public
+    neutron router-interface-add public fixed
+fi
+
+## floating/external
+if ! neutron net-show ext ; then
+    if [ x$FLOATING_VLAN != x ]; then
+        neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type vlan \
+                --router:external --provider:segmentation_id $FLOATING_VLAN --provider:physical_network physnet1
+    else
+        neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type local --router:external
+    fi
+fi
+
+if ! neutron subnet-show ext; then
+    if [ x$FLOATING_VLAN != x ]; then
+        ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
+        neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID $floatingpool $floatinggateway ext $floatingnet
+    else
+        ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
+        neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID ext $floatingnet
+    fi
 fi
 neutron router-gateway-set public ext
 # create four floatingip pools

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -617,22 +617,11 @@ crudini --set $c DEFAULT num_engine_workers "1"
 crudini --set $c heat_api workers "1"
 crudini --set $c clients_keystone auth_uri "http://$IP:35357/"
 
-
-HEAT_DOMAIN_ID=$(openstack --os-auth-url=$KEYSTONE_PUBLIC_ENDPOINT_V3 \
-    --os-identity-api-version=3 domain create heat \
-    --description "Owns users and projects created by heat" \
-    | awk '/id/  { print $4 } ')
+HEAT_DOMAIN_ID=$(get_or_create_domain heat 'Owns users and projects created by heat')
+get_or_create_user heat_domain_admin $ADMIN_PASSWORD $HEAT_DOMAIN_ID
+get_or_add_user_domain_role admin heat_domain_admin $HEAT_DOMAIN_ID
 
 crudini --set $c DEFAULT stack_user_domain $HEAT_DOMAIN_ID
-
-openstack --os-auth-url=$KEYSTONE_PUBLIC_ENDPOINT_V3 \
-    --os-identity-api-version=3 user create --password $ADMIN_PASSWORD \
-    --domain $HEAT_DOMAIN_ID heat_domain_admin \
-    --description "Manages users and projects created by heat"
-openstack --os-auth-url=$KEYSTONE_PUBLIC_ENDPOINT_V3 \
-    --os-identity-api-version=3 role add \
-    --user heat_domain_admin --domain ${HEAT_DOMAIN_ID} admin
-
 crudini --set $c DEFAULT stack_domain_admin heat_domain_admin
 crudini --set $c DEFAULT stack_domain_admin_password $ADMIN_PASSWORD
 


### PR DESCRIPTION
When kvm can not be used, use qemu instead of lxc. lxc does
not work we we do not have lxc packages available.