### PR TITLE
Fix startup of iscsid service

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -95,7 +95,7 @@ do
     start_and_enable_service $s
 done
 
-start_and_enable_service open-iscsi
+start_and_enable_service iscsid
 
 
 # Set up the database


### PR DESCRIPTION
The Liberty cleanvm jenkins job has been failing because the ISCSI daemon was not started and so nova could not boot from volume. This is a cherry-pick from https://github.com/SUSE-Cloud/openstack-quickstart/pull/55 which should hopefully resolve the issue.