### PR TITLE
Move aliases inside Keystone vhost configuration

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -387,6 +387,15 @@ Listen 35357
     <Directory /usr/bin>
         Require all granted
     </Directory>
+    Alias /identity /usr/bin/keystone-wsgi-public
+    <Location /identity>
+        SetHandler wsgi-script
+        Options +ExecCGI
+
+        WSGIProcessGroup keystone-public
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIPassAuthorization On
+    </Location>
 </VirtualHost>
 
 <VirtualHost *:35357>
@@ -403,27 +412,16 @@ Listen 35357
     <Directory /usr/bin>
         Require all granted
     </Directory>
+    Alias /identity_admin /usr/bin/keystone-wsgi-admin
+    <Location /identity_admin>
+        SetHandler wsgi-script
+        Options +ExecCGI
+
+        WSGIProcessGroup keystone-admin
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIPassAuthorization On
+    </Location>
 </VirtualHost>
-
-Alias /identity /usr/bin/keystone-wsgi-public
-<Location /identity>
-    SetHandler wsgi-script
-    Options +ExecCGI
-
-    WSGIProcessGroup keystone-public
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIPassAuthorization On
-</Location>
-
-Alias /identity_admin /usr/bin/keystone-wsgi-admin
-<Location /identity_admin>
-    SetHandler wsgi-script
-    Options +ExecCGI
-
-    WSGIProcessGroup keystone-admin
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIPassAuthorization On
-</Location>
 EOF
 
 a2enmod wsgi


### PR DESCRIPTION
This commit moves the /identity and /identity_damin aliases into
the appropriate <VirtualHost> directives. In their previous location
they applied globally and broke Horizon on setups deployed by
openstack-quickstart.