### PR TITLE
Move aliases inside Keystone vhost configuration

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -375,6 +375,15 @@ Listen 35357
     <Directory /usr/bin>
         Require all granted
     </Directory>
+    Alias /identity /usr/bin/keystone-wsgi-public
+    <Location /identity>
+        SetHandler wsgi-script
+        Options +ExecCGI
+
+        WSGIProcessGroup keystone-public
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIPassAuthorization On
+    </Location>
 </VirtualHost>
 
 <VirtualHost *:35357>
@@ -391,27 +400,16 @@ Listen 35357
     <Directory /usr/bin>
         Require all granted
     </Directory>
+    Alias /identity_admin /usr/bin/keystone-wsgi-admin
+    <Location /identity_admin>
+        SetHandler wsgi-script
+        Options +ExecCGI
+
+        WSGIProcessGroup keystone-admin
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIPassAuthorization On
+    </Location>
 </VirtualHost>
-
-Alias /identity /usr/bin/keystone-wsgi-public
-<Location /identity>
-    SetHandler wsgi-script
-    Options +ExecCGI
-
-    WSGIProcessGroup keystone-public
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIPassAuthorization On
-</Location>
-
-Alias /identity_admin /usr/bin/keystone-wsgi-admin
-<Location /identity_admin>
-    SetHandler wsgi-script
-    Options +ExecCGI
-
-    WSGIProcessGroup keystone-admin
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIPassAuthorization On
-</Location>
 EOF
 
 a2enmod wsgi


### PR DESCRIPTION
This commit moves the /identity and /identity_damin aliases into
the appropriate <VirtualHost> directives. In their previous location
they applied globally and broke Horizon on setups deployed by
openstack-quickstart.

(cherry picked from commit 7b54909becff5edba7f51da7db8a83973892d445)