### PR TITLE
Update scripts for package changes

### DIFF
--- a/scripts/keystone_data.sh
+++ b/scripts/keystone_data.sh
@@ -194,9 +194,9 @@ if [[ "$ENABLED_SERVICES" =~ "n-cpu" ]]; then
     get_or_create_endpoint \
         "placement" \
         "RegionOne" \
-        "http://$SERVICE_HOST:8780/" \
-        "http://$SERVICE_HOST:8780/" \
-        "http://$SERVICE_HOST:8780/"
+        "http://$SERVICE_HOST:8778/" \
+        "http://$SERVICE_HOST:8778/" \
+        "http://$SERVICE_HOST:8778/"
 
 fi
 

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -320,9 +320,6 @@ crudini --set $c neutron service_metadata_proxy True
 crudini --set $c neutron metadata_proxy_shared_secret $metadata_secret
 crudini --set $c keymgr fixed_key "$FIXED_KEY"
 
-# placement api
-install -m 644 /etc/apache2/vhosts.d/nova-placement-api.conf{.sample,}
-
 start_and_enable_service apache2
 # may be needed if Horizon already started apache2
 service apache2 restart


### PR DESCRIPTION
The openstack-nova package is changing the port that the nova placement
API runs on as well as defaulting to enabling the apache vhost that
serves[1] it in order to be compliant with the OpenStack install guide
as well as other package maintainers. This patch updates the quickstart
scripts to sync up with the package changes.

[1] https://build.opensuse.org/request/show/485040