### PR TITLE
Copy correct barbican-api.conf vhost file

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -806,7 +806,7 @@ if [ "x$with_barbican" = "xyes" ]; then
     crudini --set $c database connection "$DB://barbican:${mpw}@${IP}/barbican"
     crudini --set $c DEFAULT host_href http://${IP}:9311
 
-    cp /etc/apache2/conf.d/barbican-api.conf.sample /etc/apache2/conf.d/barbican-api.conf
+    cp /etc/apache2/vhosts.d/barbican-api.conf.sample /etc/apache2/vhosts.d/barbican-api.conf
 
     start_and_enable_service apache2
 


### PR DESCRIPTION
The file from the package moved to
/etc/apache2/vhosts.d/barbican-api.conf.sample so copy that file.