### PR TITLE
Use openstack instead of neutron client

### DIFF
--- a/etc/bash.openstackrc
+++ b/etc/bash.openstackrc
@@ -20,6 +20,8 @@ function setcreds() {
 	export OS_AUTH_URL=http://127.0.0.1:5000/
 	export OS_AUTH_STRATEGY=keystone
 	export OS_IDENTITY_API_VERSION=3
+	export OS_USER_DOMAIN_NAME=Default
+	export OS_PROJECT_DOMAIN_NAME=Default
 }
 
 #setcreds demo openstack

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -21,13 +21,12 @@ function run_as () {
 }
 
 function get_router_id () {
-    eval `neutron router-show -f shell -F id public`
+    local id=`openstack router show -f value -c id public`
     echo $id
 }
 
 function get_service_tenant_id () {
-    id=`openstack project show service -c id -f value`
-
+    local id=`openstack project show service -c id -f value`
     echo $id
 }
 
@@ -72,27 +71,23 @@ function stop_and_disable_service () {
 }
 
 function get_ext_bridge_name () {
-    local id
-    eval `neutron net-show -f shell -F id ext`
+    local id=`openstack network show -f value -c id ext`
     echo "brq"${id:0:11}
 }
 
 
 function get_ext_bridge_ip () {
-    local gateway_ip
-    eval `neutron subnet-show -f shell -F gateway_ip ext`
+    local gateway_ip=`openstack subnet show -f value -c gateway_ip ext`
     echo $gateway_ip
 }
 
 function get_ext_bridge_ip_prefix () {
-    local cidr
-    eval `neutron subnet-show -f shell -F cidr ext`
+    local cidr=`openstack subnet show -f value -c cidr ext`
     echo $cidr | cut -f2 -d/
 }
 
 function get_ext_bridge_cidr () {
-    local cidr
-    eval `neutron subnet-show -f shell -F cidr ext`
+    local cidr=`openstack subnet show -f value -c cidr ext`
     echo $cidr
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -209,11 +209,10 @@ function setup_keystone_authtoken() {
     crudini --set $conf $section auth_type password
     crudini --set $conf $section username $admin_user
     crudini --set $conf $section password $admin_password
-    crudini --set $conf $section user_domain_id default
+    crudini --set $conf $section user_domain_name Default
     crudini --set $conf $section project_name service
-    crudini --set $conf $section project_domain_id default
-    crudini --set $conf $section auth_url http://$IP:35357/
-    crudini --set $conf $section auth_uri http://$IP:5000/
+    crudini --set $conf $section project_domain_name Default
+    crudini --set $conf $section auth_url http://$IP:5000/
     #crudini --set $conf $section signing_dir $signing_dir
 }
 

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -593,43 +593,42 @@ fi
 
 ### create subnets
 ## fixed
-if ! neutron net-show fixed; then
-    neutron net-create fixed --tenant-id $SERVICE_TENANT_ID --shared --provider:network_type vlan \
-            --provider:segmentation_id $FIXED_VLAN  --provider:physical_network physnet1
+if ! openstack network show fixed; then
+    openstack network create --project $SERVICE_TENANT_ID --share --provider-network-type vlan \
+              --provider-segment $FIXED_VLAN --provider-physical-network physnet1 fixed
 fi
 
-if ! neutron subnet-show fixed; then
-    neutron subnet-create --name fixed --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4 fixed $testnet
+if ! openstack subnet show fixed; then
+    openstack subnet create --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4 --subnet-range $testnet --network fixed fixed
 fi
 
-if ! neutron router-show public; then
-    neutron router-create --tenant-id $SERVICE_TENANT_ID public
-    neutron router-interface-add public fixed
+if ! openstack router show public; then
+    openstack router create --project $SERVICE_TENANT_ID public
+    openstack router add subnet public fixed
 fi
 
 ## floating/external
-if ! neutron net-show ext ; then
+if ! openstack network show ext ; then
     if [ x$FLOATING_VLAN != x ]; then
-        neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type vlan \
-                --router:external --provider:segmentation_id $FLOATING_VLAN --provider:physical_network physnet1
+        openstack network create --project $SERVICE_TENANT_ID --provider-network-type vlan \
+                  --external --provider-segment $FLOATING_VLAN --provider-physical-network physnet1 ext
     else
-        neutron net-create ext --tenant-id $SERVICE_TENANT_ID --provider:network_type local --router:external
+        openstack network create --project $SERVICE_TENANT_ID --provider-network-type local --external ext
     fi
 fi
 
-if ! neutron subnet-show ext; then
+if ! openstack subnet show ext; then
+    ext_network_id=$(openstack network show ext -c id -f value)
     if [ x$FLOATING_VLAN != x ]; then
-        ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
-        neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID $floatingpool $floatinggateway ext $floatingnet
+        openstack subnet create --project $SERVICE_TENANT_ID --no-dhcp --subnet-range $floatingnet --network ext ext
     else
-        ext_network_id=$(neutron net-list | grep ' ext '  | cut -d' ' -f2)
-        neutron subnet-create --name ext --disable-dhcp --tenant-id $SERVICE_TENANT_ID ext $floatingnet
+        openstack subnet create --project $SERVICE_TENANT_ID --no-dhcp --subnet-range $floatingnet --network ext ext
     fi
 fi
-neutron router-gateway-set public ext
+openstack router set --external-gateway ext public
 # create four floatingip pools
 for i in 1 2 3 4; do
-neutron floatingip-create ext
+    openstack floating ip create ext
 done
 ### create routing configuration for external bridge
 ext_bridge_name=`get_ext_bridge_name`

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -24,7 +24,7 @@ fi
 
 if [ "x$with_tempest" = "xyes" ]; then
     install_packages openstack-ec2-api-s3 openstack-neutron-lbaas-agent \
-        openstack-neutron-vpn-agent openstack-neutron-fwaas \
+        openstack-neutron-vpnaas openstack-neutron-fwaas \
         openstack-tempest-test
     if [ "x$with_manila" = "xyes" ]; then
         install_packages  openstack-manila-test


### PR DESCRIPTION
neutron CLI is deprecated and fails currently with Queens in
openstack-quickstart with:

neutron net-create fixed --tenant-id 87ed5237568443d7bc4f11a73f2eb526 \
    --shared --provider:network_type vlan \
    --provider:segmentation_id 999 \
    --provider:physical_network physnet1
neutron CLI is deprecated and will be removed in the future. Use openstack CLI
(http://127.0.0.1:5000/v2.0/tokens): The resource could not be
 found. (HTTP 404)
 (Request-ID: req-dc216882-e9e2-4594-9806-8aa853b446b5)