### PR TITLE
quickstart: install openstack-neutron-fwaas-test

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -25,7 +25,7 @@ fi
 if [ "x$with_tempest" = "xyes" ]; then
     install_packages openstack-ec2-api-s3 openstack-neutron-lbaas-agent \
         openstack-neutron-vpnaas openstack-neutron-fwaas \
-        openstack-tempest-test
+        openstack-neutron-fwaas-test openstack-tempest-test
     if [ "x$with_manila" = "xyes" ]; then
         install_packages  openstack-manila-test
     fi
@@ -553,9 +553,15 @@ crudini --set $c_l3a DEFAULT interface_driver neutron.agent.linux.interface.Brid
 crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secret $metadata_secret
 
 if [ "x$with_tempest" = "xyes" ]; then
-    crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin"
+    crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, neutron_fwaas.services.firewall.fwaas_plugin.FirewallPlugin"
     # configure Neutron Lbaas v2 service
     crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
+    # configure Neutron FWaaS
+    crudini --set /etc/neutron/fwaas_driver.ini service_providers service_provider "FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.IptablesFirewallDriver:default"
+    crudini --set $c_l3a AGENT extensions "fwaas"
+    crudini --set $c_l3a fwaas agent_version "v1"
+    crudini --set $c_l3a fwaas driver "iptables"
+    crudini --set $c_l3a fwaas enabled "True"
 fi
 
 # the default systemd socket activation only listens on the loopback interface


### PR DESCRIPTION
Tests for openstack-neutron-neutron-fwaas have been separated
out into openstack-neutron-neutron-fwaas-test, which must be
installed explicitly. Otherwise tempest's test detection will
fail to find these tests and cause `stestr list` to exit
nonzero.

Please do not merge, yet. During testing I got past the point where `stestr list` failed, but now I'm getting test failures for various fwaas tests. Hence I may need to add more code to this PR to take care of these.