### PR TITLE
Drop openstack-neutron-lbaasv2 deployment

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -23,7 +23,7 @@ if [ "x$node_is_compute" = "xyes" ]; then
 fi
 
 if [ "x$with_tempest" = "xyes" ]; then
-    install_packages openstack-ec2-api-s3 openstack-neutron-lbaas-agent \
+    install_packages openstack-ec2-api-s3 \
         openstack-neutron-vpnaas openstack-neutron-fwaas \
         python-keystone-tempest-plugin \
         python-heat-tempest-plugin \
@@ -586,11 +586,9 @@ crudini --set $c_l3a DEFAULT interface_driver neutron.agent.linux.interface.Brid
 crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secret $metadata_secret
 
 if [ "x$with_tempest" = "xyes" ]; then
-    crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, firewall_v2, neutron.services.qos.qos_plugin.QoSPlugin, trunk"
+    crudini --set $c DEFAULT service_plugins "neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, firewall_v2, neutron.services.qos.qos_plugin.QoSPlugin, trunk"
     # configure Neutron VPNaaS
     crudini --set /etc/neutron/neutron_vpnaas.conf service_providers service_provider VPN:ipsec:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
-    # configure Neutron Lbaas v2 service
-    crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
     # configure Neutron FWaaS
     crudini --set /etc/neutron/fwaas_driver.ini service_providers service_provider "FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.agents.agents.FirewallAgentDriver:default"
     crudini --set $c_l3a AGENT extensions "fwaas_v2"
@@ -632,10 +630,6 @@ for s in openstack-keystone \
 do
     start_and_enable_service $s
 done
-
-if [ "x$with_tempest" = "xyes" ]; then
-    start_and_enable_service openstack-neutron-lbaasv2-agent
-fi
 
 ### create subnets
 ## fixed


### PR DESCRIPTION
It is deprecated[1] and does no longer work so do not deploy it.

[1] https://wiki.openstack.org/wiki/Neutron/LBaaS/Deprecation