### PR TITLE
Switch to FWaasV2 implementation

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -553,14 +553,14 @@ crudini --set $c_l3a DEFAULT interface_driver neutron.agent.linux.interface.Brid
 crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secret $metadata_secret
 
 if [ "x$with_tempest" = "xyes" ]; then
-    crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, neutron_fwaas.services.firewall.fwaas_plugin.FirewallPlugin"
+    crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, firewall_v2"
     # configure Neutron Lbaas v2 service
     crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
     # configure Neutron FWaaS
-    crudini --set /etc/neutron/fwaas_driver.ini service_providers service_provider "FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.IptablesFirewallDriver:default"
-    crudini --set $c_l3a AGENT extensions "fwaas"
-    crudini --set $c_l3a fwaas agent_version "v1"
-    crudini --set $c_l3a fwaas driver "iptables"
+    crudini --set /etc/neutron/fwaas_driver.ini service_providers service_provider "FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.agents.agents.FirewallAgentDriver:default"
+    crudini --set $c_l3a AGENT extensions "fwaas_v2"
+    crudini --set $c_l3a fwaas agent_version "v2"
+    crudini --set $c_l3a fwaas driver "iptables_v2"
     crudini --set $c_l3a fwaas enabled "True"
 fi
 

--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -25,9 +25,25 @@ fi
 if [ "x$with_tempest" = "xyes" ]; then
     install_packages openstack-ec2-api-s3 openstack-neutron-lbaas-agent \
         openstack-neutron-vpnaas openstack-neutron-fwaas \
+        python-keystone-tempest-plugin \
+        python-heat-tempest-plugin \
+        python-neutron-tempest-plugin \
         openstack-neutron-fwaas-test openstack-tempest-test
+
+    if [ "x$with_barbican" = "xyes" ]; then
+        install_packages python-barbican-tempest-plugin
+    fi
+
+    if [ "x$with_designate" = "xyes" ]; then
+        install_packages python-designate-tempest-plugin
+    fi
+
     if [ "x$with_manila" = "xyes" ]; then
-        install_packages  openstack-manila-test
+        install_packages  openstack-manila-test python-manila-tempest-plugin
+    fi
+
+    if [ "x$with_magnum" = "xyes" ]; then
+        install_packages python-manila-tempest-plugin
     fi
 fi
 


### PR DESCRIPTION
Just a mere week after we enabled FWaaSv1 in quickstart upstream
decided to finally remove FWaaSv1 and ship only FWaaSv2. so
we need to switch to the non-deprecated and non-removed implementation.