### PR TITLE
Stop installing python-designateclient

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -77,8 +77,7 @@ fi
 if [ "x$with_designate" = "xyes" ]; then
     install_packages openstack-designate openstack-designate-api\
                      openstack-designate-central openstack-designate-producer \
-                     openstack-designate-sink openstack-designate-worker \
-                     python-designateclient
+                     openstack-designate-sink openstack-designate-worker
 fi
 
 if [ "x$with_gnocchi" = "xyes" ]; then


### PR DESCRIPTION
Recently we switched to singlespec, so we need to pick
python3 or python2 depending on the distribution. Let
the pattern-OpenStackClient figure that out