### PR TITLE
Add debug output for keystone data

### DIFF
--- a/scripts/keystone_data.sh
+++ b/scripts/keystone_data.sh
@@ -135,7 +135,7 @@ function create_keystone_accounts {
 # script starts here
 #################################################
 
-set -e
+set -ex
 
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-secrete}
 SERVICE_PASSWORD=${SERVICE_PASSWORD:-$ADMIN_PASSWORD}


### PR DESCRIPTION
The automation repo already runs the demosetup script with -x. It just
makes sense to be able to see what the script is doing in the CI.