### PR TITLE
Update keystone config options

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -1121,25 +1121,18 @@ if [ "x$with_tempest" = "xyes" -a -e /etc/tempest/tempest.conf ]; then
     crudini --set /etc/tempest/tempest.conf auth use_dynamic_credentials True
     crudini --set /etc/tempest/tempest.conf auth tempest_roles Member
     crudini --set /etc/tempest/tempest.conf auth admin_domain_name Default
-    crudini --set /etc/tempest/tempest.conf auth admin_tenant_name admin
+    crudini --set /etc/tempest/tempest.conf auth admin_project_name admin
     crudini --set /etc/tempest/tempest.conf auth admin_password $pw
     crudini --set /etc/tempest/tempest.conf auth admin_username admin
     crudini --set /etc/tempest/tempest.conf identity uri $KEYSTONE_PUBLIC_ENDPOINT
     crudini --set /etc/tempest/tempest.conf identity uri_v3 $KEYSTONE_PUBLIC_ENDPOINT_V3
     crudini --set /etc/tempest/tempest.conf identity auth_version v3
-    crudini --set /etc/tempest/tempest.conf identity username demo
-    crudini --set /etc/tempest/tempest.conf identity tenant_name demo
-    crudini --set /etc/tempest/tempest.conf identity alt_password $pw
-    crudini --set /etc/tempest/tempest.conf identity password $pw
     crudini --set /etc/tempest/tempest.conf compute-feature-enabled change_password False
     crudini --set /etc/tempest/tempest.conf compute-feature-enabled live_migration False
     crudini --set /etc/tempest/tempest.conf compute-feature-enabled vnc_console true
     crudini --set /etc/tempest/tempest.conf compute-feature-enabled resize true
     crudini --set /etc/tempest/tempest.conf compute fixed_network_name fixed
     crudini --set /etc/tempest/tempest.conf compute network_for_ssh ext
-    crudini --set /etc/tempest/tempest.conf compute-admin username admin
-    crudini --set /etc/tempest/tempest.conf compute-admin tenant_name admin
-    crudini --set /etc/tempest/tempest.conf compute-admin password $pw
     crudini --set /etc/tempest/tempest.conf orchestration stack_owner_role _member_
     crudini --set /etc/tempest/tempest.conf network public_network_id $ext_network_id
     crudini --set /etc/tempest/tempest.conf service_available neutron True


### PR DESCRIPTION
Config options named after keystone 'tenants' were removed[1] and replace
with options named after keystone 'projects'. The result of not setting
the 'project' options was that tempest auth requests would be 'unscoped'
and by default not result in a catalog[2], which meant that it could not
look up service endpoints and would fail with

  EndpointNotFound: Endpoint not found
  Details: No matching service found in the catalog.

even though the endpoint was in fact in the catalog. This change fixes
the issue by updating the tempest config to use real config options.

[1] https://review.opendev.org/661664
[2] https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail#password-authentication-with-unscoped-authorization