### PR TITLE
Use correct python version when calling django's migrate mgmt cmd

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -287,7 +287,11 @@ EODASHDB
 SESSION_COOKIE_SECURE = CSRF_COOKIE_SECURE = USE_SSL
 EOSEC
     # sync dashboard DB "after" the database is created
-    run_as wwwrun "cd /srv/www/openstack-dashboard; umask 0027; python -m 'manage' migrate --noinput"
+    if rpm -q python-Django; then
+        run_as wwwrun "cd /srv/www/openstack-dashboard; umask 0027; python -m 'manage' migrate --noinput"
+    else
+        run_as wwwrun "cd /srv/www/openstack-dashboard; umask 0027; python3 -m 'manage' migrate --noinput"
+    fi
 
     start_and_enable_service apache2
 fi


### PR DESCRIPTION
Depending on the installed Django package (py2 vs. py3), call the
correct python version to execute the DB migration.
This fixes

ImportError: No module named django.core.management

when calling "python -m ..." in a python3 environment where only
python3-Django is installed.