### PR TITLE
Set a service provider for neutron vpnaas

### DIFF
--- a/scripts/openstack-quickstart-demosetup
+++ b/scripts/openstack-quickstart-demosetup
@@ -587,6 +587,8 @@ crudini --set /etc/neutron/metadata_agent.ini DEFAULT metadata_proxy_shared_secr
 
 if [ "x$with_tempest" = "xyes" ]; then
     crudini --set $c DEFAULT service_plugins "neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2, neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, neutron.services.vpn.plugin.VPNDriverPlugin, neutron.services.metering.metering_plugin.MeteringPlugin, firewall_v2, neutron.services.qos.qos_plugin.QoSPlugin, trunk"
+    # configure Neutron VPNaaS
+    crudini --set /etc/neutron/neutron_vpnaas.conf service_providers service_provider VPN:ipsec:neutron_vpnaas.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
     # configure Neutron Lbaas v2 service
     crudini --set /etc/neutron/neutron_lbaas.conf service_providers service_provider "LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default"
     # configure Neutron FWaaS


### PR DESCRIPTION
This was previously done in the rpm package but upstream does not set
a default provider so we won't do that in the package and do it here
now.