### PR TITLE
Export OS_PROJECT_NAME

### DIFF
--- a/etc/bash.openstackrc
+++ b/etc/bash.openstackrc
@@ -17,6 +17,7 @@ function setcreds() {
 	export EC2_ACCESS_KEY=$1
 	export EC2_SECRET_KEY=$2
 	export OS_TENANT_NAME=admin
+	export OS_PROJECT_NAME=$OS_TENANT_NAME
 	export OS_AUTH_URL=http://127.0.0.1:5000/
 	export OS_AUTH_STRATEGY=keystone
 	export OS_IDENTITY_API_VERSION=3


### PR DESCRIPTION
"cinder create" will fail with:

ERROR: You must provide a project_id or project_name ...

if OS_PROJECT_NAME is not set.